### PR TITLE
Rustfmt, consistent macro usage, and use_functor test.

### DIFF
--- a/src/applicative.rs
+++ b/src/applicative.rs
@@ -1,64 +1,60 @@
 use core::*;
 use functor::*;
-use std::ops::Deref;
-use core::*;
 
 pub trait Applicative: Functor {
-    fn pure(s:unplug!(Self, A)) -> Self;
-    fn app<B, F>(f:plug!(Self[F]), s:Self) -> plug!(Self[B]) where
-        F:Fn(unplug!(Self, A)) -> B,
-        Self:Plug<F>+Plug<B>+Unplug,
-        plug!(Self[F]):Unplug<F=unplug!(Self, F),A=F>+Plug<F>+Clone,
-        unplug!(Self, F):Plug<F>
-        ;
+    fn pure(s: unplug!(Self, A)) -> Self;
+    fn app<B, F>(f: plug!(Self[F]), s: Self) -> plug!(Self[B])
+    where
+        F: Fn(unplug!(Self, A)) -> B,
+        Self: Plug<F> + Plug<B> + Unplug,
+        plug!(Self[F]): Unplug<F = unplug!(Self, F), A = F> + Plug<F> + Clone,
+        unplug!(Self, F): Plug<F>;
 }
 
 impl<A> Applicative for Box<A> {
-    fn pure(a:A) -> Self {
+    fn pure(a: A) -> Self {
         Box::new(a)
     }
 
-    fn app<B, F>(f:plug!(Self[F]), s:Self) -> plug!(Self[B])
+    fn app<B, F>(f: plug!(Self[F]), s: Self) -> plug!(Self[B])
     where
-        F:Fn(unplug!(Self, A)) -> B
+        F: Fn(unplug!(Self, A)) -> B,
     {
         Box::new((*f)(*s))
     }
 }
 
-impl<A:Clone> Applicative for Vec<A> {
-    fn pure(a:A) -> Self {
+impl<A: Clone> Applicative for Vec<A> {
+    fn pure(a: A) -> Self {
         vec![a]
     }
-    fn app<B, F>(fs:plug!(Self[F]), s:Self) -> plug!(Self[B])
+    fn app<B, F>(fs: plug!(Self[F]), s: Self) -> plug!(Self[B])
     where
-        F:Fn(unplug!(Self, A)) -> B,
+        F: Fn(unplug!(Self, A)) -> B,
         plug!(Self[F]): Clone,
     {
-        let flat:Vec<B> = 
-        Functor::map(|x:A|
-            Functor::map(|f:F|
-                f(x.clone()),
-            fs.clone()),
-        s).into_iter().flatten().collect();
+        let flat: Vec<B> = Functor::map(|x: A| Functor::map(|f: F| f(x.clone()), fs.clone()), s)
+            .into_iter()
+            .flatten()
+            .collect();
         flat
     }
 }
 
 impl<A> Applicative for Option<A> {
-    fn pure(a:A) -> Self {
+    fn pure(a: A) -> Self {
         Some(a)
     }
-    fn app<B, F>(fs:plug!(Self[F]), s:Self) -> plug!(Self[B])
+    fn app<B, F>(fs: plug!(Self[F]), s: Self) -> plug!(Self[B])
     where
-        F:Fn(unplug!(Self, A)) -> B
+        F: Fn(unplug!(Self, A)) -> B,
     {
         match fs {
             Some(f) => match s {
                 Some(x) => Some(f(x)),
-                None => None
+                None => None,
             },
-            None => None
+            None => None,
         }
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,38 +1,43 @@
-
 #[allow(non_camel_case_types, bare_trait_objects)]
 pub struct forall_t;
 
-pub struct Concrete<M:Unplug+Plug<A>,A>
-{
-    pub unwrap:<M as Plug<A>>::result_t
+pub struct Concrete<M: Unplug + Plug<A>, A> {
+    pub unwrap: <M as Plug<A>>::result_t,
 }
 
-impl<M:Unplug+Plug<A>,A> Clone for Concrete<M,A> where <M as Plug<A>>::result_t:Clone, <M as Plug<A>>::result_t:Unplug<F=M,A=A> {
+impl<M: Unplug + Plug<A>, A> Clone for Concrete<M, A>
+where
+    <M as Plug<A>>::result_t: Clone,
+    <M as Plug<A>>::result_t: Unplug<F = M, A = A>,
+{
     fn clone(&self) -> Self {
         Concrete::of(self.unwrap.clone())
     }
 }
 
-impl<M:Unplug+Plug<A>,A> Concrete<M,A> {
-    pub fn of<MA:Unplug<F=M,A=A>+Plug<A>>(x:MA) -> Self where M:Plug<A, result_t = MA> {
+impl<M: Unplug + Plug<A>, A> Concrete<M, A> {
+    pub fn of<MA: Unplug<F = M, A = A> + Plug<A>>(x: MA) -> Self
+    where
+        M: Plug<A, result_t = MA>,
+    {
         Concrete { unwrap: x }
     }
 }
 
-pub trait Unplug:Sized {
-    type F:Unplug+Plug<Self::A>;
+pub trait Unplug: Sized {
+    type F: Unplug + Plug<Self::A>;
     type A;
 }
 
-pub trait Plug<A>:Sized {
-    type result_t:Plug<A>+Unplug;
+pub trait Plug<A>: Sized {
+    type result_t: Plug<A> + Unplug;
 }
 
-impl<M:Plug<A>+Plug<B>+Unplug,A,B> Plug<B> for Concrete<M,A> {
-    type result_t = Concrete<M,B>;
+impl<M: Plug<A> + Plug<B> + Unplug, A, B> Plug<B> for Concrete<M, A> {
+    type result_t = Concrete<M, B>;
 }
 
-impl<M:Plug<A>+Unplug,A> Unplug for Concrete<M,A> {
+impl<M: Plug<A> + Unplug, A> Unplug for Concrete<M, A> {
     type F = M;
     type A = A;
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,14 +1,25 @@
 #[allow(non_camel_case_types, bare_trait_objects)]
 pub struct forall_t;
 
+macro_rules! plug {
+    ($t1:ty [ $t2:ty ]) => {
+        <$t1 as Plug<$t2>>::result_t
+    };
+}
+
+macro_rules! unplug {
+    ($t:ty, $v:ident) => {
+        <$t as Unplug>::$v
+    };
+}
+
 pub struct Concrete<M: Unplug + Plug<A>, A> {
-    pub unwrap: <M as Plug<A>>::result_t,
+    pub unwrap: plug!(M[A]),
 }
 
 impl<M: Unplug + Plug<A>, A> Clone for Concrete<M, A>
 where
-    <M as Plug<A>>::result_t: Clone,
-    <M as Plug<A>>::result_t: Unplug<F = M, A = A>,
+    plug!(M[A]): Clone + Unplug<F = M, A = A>,
 {
     fn clone(&self) -> Self {
         Concrete::of(self.unwrap.clone())
@@ -40,16 +51,4 @@ impl<M: Plug<A> + Plug<B> + Unplug, A, B> Plug<B> for Concrete<M, A> {
 impl<M: Plug<A> + Unplug, A> Unplug for Concrete<M, A> {
     type F = M;
     type A = A;
-}
-
-macro_rules! plug {
-    ($t1:ty [ $t2:ty ]) => {
-        <$t1 as Plug<$t2>>::result_t
-    };
-}
-
-macro_rules! unplug {
-    ($t:ty, $v:ident) => {
-        <$t as Unplug>::$v
-    };
 }

--- a/src/functor.rs
+++ b/src/functor.rs
@@ -1,32 +1,34 @@
 use core::*;
 
-pub trait Functor: Unplug+Plug<unplug!(Self, A)> {
-    fn map<B, F>(f:F, s:Self) -> plug!(Self[B]) where
-        Self:Plug<B>,
-        F:Fn(<Self as Unplug>::A) -> B
-        ;
+pub trait Functor: Unplug + Plug<unplug!(Self, A)> {
+    fn map<B, F>(f: F, s: Self) -> plug!(Self[B])
+    where
+        Self: Plug<B>,
+        F: Fn(<Self as Unplug>::A) -> B;
 }
 
 impl<A> Functor for Box<A> {
-    fn map<B,F>(f:F, s:Self) -> plug!(Self[B]) where
-        F:Fn(unplug!(Self, A)) -> B
-    { 
+    fn map<B, F>(f: F, s: Self) -> plug!(Self[B])
+    where
+        F: Fn(unplug!(Self, A)) -> B,
+    {
         Box::new(f(*s))
     }
 }
 
 impl<A> Functor for Vec<A> {
-    fn map<B,F>(f:F, s:Self) -> plug!(Self[B]) where
-        F:Fn(unplug!(Self, A)) -> B
-    { 
+    fn map<B, F>(f: F, s: Self) -> plug!(Self[B])
+    where
+        F: Fn(unplug!(Self, A)) -> B,
+    {
         s.into_iter().map(f).collect()
     }
 }
 
-
 impl<A> Functor for Option<A> {
-    fn map<B,F>(f:F, s:Self) -> plug!(Self[B]) where
-        F:Fn(unplug!(Self, A)) -> B
+    fn map<B, F>(f: F, s: Self) -> plug!(Self[B])
+    where
+        F: Fn(unplug!(Self, A)) -> B,
     {
         s.map(f)
     }
@@ -36,7 +38,7 @@ impl<A> Functor for Option<A> {
 fn it_compiles<F:Functor,A,B,C>(functor:F, fun:impl Fn(A)->B, fun2:impl Fn(B)->C) -> <F as Plug<C>>::result_t where
     F:Plug<A>+Plug<B>+Plug<C>+Unplug<A=A>,
     <F as Unplug>::F: Plug<A> + Plug<B> + Plug<C>
-{
+    {
     let cmp = |x|fun2(fun(x));
-    Functor::map(cmp, functor)
-}
+        Functor::map(cmp, functor)
+    }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,8 +1,8 @@
-use core::{Plug, Unplug, forall_t};
+use core::{forall_t, Plug, Unplug};
 
 macro_rules! simple_impl {
     ($name:ident) => {
-        impl<A,B> Plug<B> for $name<A>{
+        impl<A, B> Plug<B> for $name<A> {
             type result_t = $name<B>;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #[macro_use]
 pub mod core;
-pub mod functor;
 pub mod applicative;
-pub mod monad;
+pub mod functor;
 pub mod impls;
-
+pub mod monad;
 
 #[cfg(test)]
 mod tests {

--- a/src/meltdown.rs
+++ b/src/meltdown.rs
@@ -2,12 +2,15 @@ use core::*;
 
 #[test]
 fn main() {
-    let fv = Concrete::of(vec![1,2,3i32]);
+    let fv = Concrete::of(vec![1, 2, 3i32]);
     //Concrete::of helps the compiler infer the types through constraint manipulation;
     //simply using the naked constructor might fail to resolve the types
     //let fv = Concrete{unwrap:vec![1,2,3i32]};
-    
-    let fvr = Functor::map((|x|x as i64+1) as fn(i32)->i64,fv);
-    let avr = Applicative::app(Concrete::of(vec![(|x:i64|x+1) as fn(i64)->i64,|x:i64|-x]), fvr);
+
+    let fvr = Functor::map((|x| x as i64 + 1) as fn(i32) -> i64, fv);
+    let avr = Applicative::app(
+        Concrete::of(vec![(|x: i64| x + 1) as fn(i64) -> i64, |x: i64| -x]),
+        fvr,
+    );
     println!("{:?}", avr.unwrap);
 }

--- a/src/monad.rs
+++ b/src/monad.rs
@@ -44,20 +44,17 @@ impl<A> Monad for Option<A> {
 mod tests {
     use super::*;
     ///wew lad
-    fn higher_poly_demo<'a, M: Monad, A: 'a + Clone, B: 'a + Clone, F>(
-        m: M,
-        f: F,
-    ) -> <M as Plug<B>>::result_t
+    fn higher_poly_demo<'a, M: Monad, A: 'a + Clone, B: 'a + Clone, F>(m: M, f: F) -> plug!(M[B])
     where
-        M: Plug<A> + Plug<B> + Unplug<A = A>, //+Plug<F>+Plug<Fn(A)-><M as Plug<B>>::result_t>,
-        M: Plug<Box<Fn(A) -> <M as Plug<B>>::result_t>>,
+        M: Plug<A> + Plug<B> + Unplug<A = A>, //+Plug<F>+Plug<Fn(A)->plug!(M[B])>,
+        M: Plug<Box<Fn(A) -> plug!(M[B])>>,
         M: Plug<F>,
         F: 'static,
-        <M as Unplug>::F: Plug<A> + Plug<B>,
-        <M as Plug<B>>::result_t: Monad + Unplug<A = B> + 'a,
-        <<M as Plug<B>>::result_t as Unplug>::F: Plug<B>,
+        unplug!(M, F): Plug<A> + Plug<B>,
+        plug!(M[B]): Monad + Unplug<A = B> + 'a,
+        unplug!(plug!(M[B]), F): Plug<B>,
         F: Fn(A) -> B + 'a,
-        //F:Fn(A) -> <M as Plug<B>>::result_t + Clone,
+        //F:Fn(A) -> plug!(M[B]) + Clone,
     {
         let cl = Box::new(move |x| Applicative::pure(f(x)));
         Monad::bind::<Box<Fn(A) -> _>, B>(cl as Box<Fn(A) -> _>, m)

--- a/src/monad.rs
+++ b/src/monad.rs
@@ -1,46 +1,41 @@
-use core::*;
 use applicative::*;
+use core::*;
 
-pub trait Monad : Applicative {
-    fn bind<F,B>(f:F, s:Self) -> plug!(Self[B])
-    where 
-        Self:Plug<F>+Plug<B>,
-        F:Fn(unplug!(Self, A)) -> plug!(Self[B])
-    ;
+pub trait Monad: Applicative {
+    fn bind<F, B>(f: F, s: Self) -> plug!(Self[B])
+    where
+        Self: Plug<F> + Plug<B>,
+        F: Fn(unplug!(Self, A)) -> plug!(Self[B]);
 }
 
 impl<A> Monad for Box<A> {
-    fn bind<F,B>(f:F, s:Self) -> plug!(Self[B])
-    where 
-        Self:Plug<F>+Plug<B>,
-        F:Fn(unplug!(Self, A)) -> plug!(Self[B])
+    fn bind<F, B>(f: F, s: Self) -> plug!(Self[B])
+    where
+        Self: Plug<F> + Plug<B>,
+        F: Fn(unplug!(Self, A)) -> plug!(Self[B]),
     {
         f(*s)
     }
 }
 
-impl<A:Clone> Monad for Vec<A> {
-    fn bind<F,B>(f:F, s:Self) -> plug!(Self[B])
+impl<A: Clone> Monad for Vec<A> {
+    fn bind<F, B>(f: F, s: Self) -> plug!(Self[B])
     where
-        F:Fn(unplug!(Self, A)) -> plug!(Self[B])
+        F: Fn(unplug!(Self, A)) -> plug!(Self[B]),
     {
-        let res:Vec<B> = 
-            s
-            .into_iter()
-            .map(|x|f(x))
-            .flatten().collect();
+        let res: Vec<B> = s.into_iter().map(|x| f(x)).flatten().collect();
         res
     }
 }
 
 impl<A> Monad for Option<A> {
-    fn bind<F,B>(f:F, s:Self) -> plug!(Self[B])
+    fn bind<F, B>(f: F, s: Self) -> plug!(Self[B])
     where
-        F:Fn(unplug!(Self, A)) -> plug!(Self[B])
+        F: Fn(unplug!(Self, A)) -> plug!(Self[B]),
     {
         match s {
             Some(x) => f(x),
-            None => None
+            None => None,
         }
     }
 }
@@ -49,24 +44,28 @@ impl<A> Monad for Option<A> {
 mod tests {
     use super::*;
     ///wew lad
-    fn higher_poly_demo<'a,M:Monad,A:'a+Clone,B:'a+Clone,F>(m:M, f:F) -> <M as Plug<B>>::result_t where
-        M:Plug<A>+Plug<B>+Unplug<A=A>,//+Plug<F>+Plug<Fn(A)-><M as Plug<B>>::result_t>,
-        M:Plug<Box<Fn(A)-><M as Plug<B>>::result_t>>,
-        M:Plug<F>,
-        F:'static,
-        <M as Unplug>::F:Plug<A>+Plug<B>,
-        <M as Plug<B>>::result_t:Monad+Unplug<A=B>+'a,
-        <<M as Plug<B>>::result_t as Unplug>::F:Plug<B>,
-        F:Fn(A) -> B+'a,
+    fn higher_poly_demo<'a, M: Monad, A: 'a + Clone, B: 'a + Clone, F>(
+        m: M,
+        f: F,
+    ) -> <M as Plug<B>>::result_t
+    where
+        M: Plug<A> + Plug<B> + Unplug<A = A>, //+Plug<F>+Plug<Fn(A)-><M as Plug<B>>::result_t>,
+        M: Plug<Box<Fn(A) -> <M as Plug<B>>::result_t>>,
+        M: Plug<F>,
+        F: 'static,
+        <M as Unplug>::F: Plug<A> + Plug<B>,
+        <M as Plug<B>>::result_t: Monad + Unplug<A = B> + 'a,
+        <<M as Plug<B>>::result_t as Unplug>::F: Plug<B>,
+        F: Fn(A) -> B + 'a,
         //F:Fn(A) -> <M as Plug<B>>::result_t + Clone,
     {
-        let cl = Box::new(move |x|Applicative::pure(f(x)));
-        Monad::bind::<Box<Fn(A)->_>,B>(cl as Box<Fn(A)->_>, m)
+        let cl = Box::new(move |x| Applicative::pure(f(x)));
+        Monad::bind::<Box<Fn(A) -> _>, B>(cl as Box<Fn(A) -> _>, m)
     }
 
     #[test]
     fn use_higher_poly() {
-        let f = |x|x+1;
+        let f = |x| x + 1;
         let p1 = Some(5);
         let p2 = vec![5];
         let p3 = Box::new(5);


### PR DESCRIPTION
I've run cargo fmt for improved readability and consistent syntax.
I've also replaced leftover <F as {Plug, Unplug}>::{result_t, A} with macros.
Additionally I've added use_functor test.